### PR TITLE
Separate payer function for init strike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "staking_options"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/programs/staking-options/Cargo.toml
+++ b/programs/staking-options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking_options"
-version = "0.0.4"
+version = "0.0.5"
 description = "Staking options from dual finance"
 edition = "2018"
 

--- a/programs/staking-options/src/instructions/init_strike.rs
+++ b/programs/staking-options/src/instructions/init_strike.rs
@@ -56,3 +56,59 @@ impl<'info> InitStrike<'info> {
         Ok(())
     }
 }
+
+pub fn init_strike_with_payer(ctx: Context<InitStrikeWithPayer>, strike: u64) -> Result<()> {
+    ctx.accounts.state.strikes.push(strike);
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(strike: u64)]
+pub struct InitStrikeWithPayer<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    // State holding all the data for the stake that the staker wants to do.
+    // Needs to be updated to reflect the new strike.
+    #[account(mut,
+        seeds = [
+            SO_CONFIG_SEED,
+            state.so_name.as_bytes(),
+            &state.base_mint.key().to_bytes()
+        ],
+        bump = state.state_bump
+    )]
+    pub state: Box<Account<'info, State>>,
+
+    #[account(
+        init,
+        payer = payer,
+        seeds = [SO_MINT_SEED, &state.key().to_bytes(), &strike.to_be_bytes()],
+        bump,
+        mint::decimals = 0,
+        mint::authority = option_mint)]
+    pub option_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> InitStrikeWithPayer<'info> {
+    pub fn validate_accounts(&self, _strike: u64) -> Result<()> {
+        // Verify the authority to init strike against the state authority
+        assert_keys_eq!(self.authority, self.state.authority);
+
+        // Verify that it is not already expired
+        check_not_expired!(self.state.subscription_period_end);
+
+        // Make sure there are not too many strikes already.
+        invariant!(self.state.strikes.len() < 100);
+
+        Ok(())
+    }
+}

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -64,6 +64,11 @@ pub mod staking_options {
         init_strike::init_strike(ctx, strike)
     }
 
+    #[access_control(ctx.accounts.validate_accounts(strike))]
+    pub fn init_strike_with_payer(ctx: Context<InitStrikeWithPayer>, strike: u64) -> Result<()> {
+        init_strike::init_strike_with_payer(ctx, strike)
+    }
+
     #[access_control(ctx.accounts.validate_accounts(amount))]
     pub fn issue(ctx: Context<Issue>, amount: u64, strike: u64) -> Result<()> {
         issue::issue(ctx, amount, strike)


### PR DESCRIPTION
This is needed when the authority calling is a PDA that is not funded