### PR TITLE
Block if subscription date is config after expo

### DIFF
--- a/programs/staking-options/src/instructions/config.rs
+++ b/programs/staking-options/src/instructions/config.rs
@@ -125,7 +125,7 @@ impl<'info> Config<'info> {
         check_not_expired!(option_expiration);
         check_not_expired!(subscription_period_end);
 
-        invariant!(subscription_period_end <= option_expiration);
+        invariant!(subscription_period_end > option_expiration);
 
         // Cannot verify the token type of the quote_account because it could be
         // something else for downside SO.


### PR DESCRIPTION
Reverse logic so we block subscription dates that fall after expiration, but allow them before or equal to expiration.