### PR TITLE
Make a separate issue authority

### DIFF
--- a/.github/workflows/ci-soteria.yml
+++ b/.github/workflows/ci-soteria.yml
@@ -3,6 +3,7 @@ name: Soteria Scan
 on:
   push:
     branches: main
+  workflow_dispatch:
   pull_request:
 
 env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,18 +371,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe233b960f12f8007e3db2d136e3cb1c291bfd7396e384ee76025fc1a3932b4"
+checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -805,18 +805,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.7"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "staking_options"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1263,7 +1263,6 @@ dependencies = [
  "solana-program",
  "solana-security-txt",
  "spl-token",
- "vipers",
 ]
 
 [[package]]
@@ -1285,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -1344,17 +1343,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vipers"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ae9a95d96cec623d9ff69d026671c79a0001d3df9bc825bfa648297f7c05bf"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "num-traits",
-]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,42 @@
 version = 3
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aes-gcm-siv"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.3.0",
+ "ctr",
+ "polyval",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b75d05b6b4ac9d95bb6e3b786b27d3a708c4c5a87c92ffaa25bbe9ae4c5d91"
+checksum = "2d5e1a413b311b039d29b61d0dbb401c9dbf04f792497ceca87593454bf6d7dd"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -38,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485351a6d8157750d10d88c8e256f1bf8339262b2220ae9125aed3471309b5de"
+checksum = "cca9aeaf633c6e2365fed0525dcac68610be58eee5dc69d3b86fe0b1d4b320b9"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -53,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc632c540913dd051a78b00587cc47f57013d303163ddfaf4fa18717f7ccc1e0"
+checksum = "788e44f9e8501dabeb6f9229da0f3268fb2ae3208912608ffaa056a72031296f"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -64,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5bd1dcfa7f3bc22dacef233d70a9e0bee269c4ac484510662f257cba2353a1"
+checksum = "ea0c4d8c7e4a2605ede6fcdced9690288b2f74e24768619a85229d57e597bc97"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -76,26 +112,12 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6f9e6ce551ac9a177a45c99a65699a860c9e95fac68675138af1246e2591b0"
+checksum = "7a3b07d5c5d87b5edc72428b447b8e9ee1143b83dd1afc6a6b1d352c6a6164d8"
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "anchor-attribute-interface"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d104aa17418cb329ed7418b227e083d5f326a27f26ce98f5d92e33da62a5f459"
-dependencies = [
- "anchor-syn",
- "anyhow",
- "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -103,22 +125,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6831b920b173c004ddf7ae1167d1d25e9f002ffcb1773bbc5c7ce532a4441e1"
-dependencies = [
- "anchor-syn",
- "anyhow",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "anchor-attribute-state"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde147b10c71d95dc679785db0b5f3abac0091f789167aa62ac0135e2f54e8b9"
+checksum = "b22ad0445115dbea5869b1d062da49ae125abed9132fc20c33227f25e42dfa6b"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -129,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cde98a0e1a56046b040ff591dfda391f88917af2b6487d02b45093c05be3514"
+checksum = "48daeff6781ba2f02961b0ad211feb9a2de75af345d42c62b1a252fd4dfb0724"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -141,20 +150,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-lang"
-version = "0.24.2"
+name = "anchor-derive-space"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85dd2c5e29e20c7f4701a43724d6cd5406d0ee5694705522e43da0f26542a84"
+checksum = "c4fe2886f92c4f33ec1b2b8b2b43ca1b9070cf4929e63c7eaaa09a9f2c0d5123"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anchor-lang"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbe5d1c7c057c6d63b4f2f538a320e4a22111126c9966340c3d9490e2f15ed1"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
  "anchor-attribute-constant",
  "anchor-attribute-error",
  "anchor-attribute-event",
- "anchor-attribute-interface",
  "anchor-attribute-program",
- "anchor-attribute-state",
  "anchor-derive-accounts",
+ "anchor-derive-space",
  "arrayref",
  "base64 0.13.1",
  "bincode",
@@ -166,31 +185,31 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0188c33b4a3c124c4e593f2b440415aaea70a7650fac6ba0772395385d71c003"
+checksum = "75cc8066fbd45e0e03edf48342c79265aa34ca76cefeace48ef6c402b6946665"
 dependencies = [
  "anchor-lang",
  "solana-program",
  "spl-associated-token-account",
  "spl-token",
+ "spl-token-2022 0.5.0",
 ]
 
 [[package]]
 name = "anchor-syn"
-version = "0.24.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03549dc2eae0b20beba6333b14520e511822a6321cdb1760f841064a69347316"
+checksum = "11cb31fe143aedb36fc41409ea072aa0b840cbea727e62eb2ff6e7b6cea036ff"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",
  "heck",
  "proc-macro2",
- "proc-macro2-diagnostics",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "syn",
  "thiserror",
 ]
@@ -200,6 +219,97 @@ name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+
+[[package]]
+name = "ark-bn254"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea691771ebbb28aea556c044e2e5c5227398d840cee0c34d4d20fa8eb2689e8c"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea978406c4b1ca13c2db2373b05cc55429c3575b8b21f1b9ee859aa5b03dd42"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "array-bytes"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad284aeb45c13f2fb4f084de4a420ebf447423bdf9386c0540ce33cb3ef4b8c"
 
 [[package]]
 name = "arrayref"
@@ -214,12 +324,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -256,6 +372,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "blake3"
@@ -303,7 +428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
  "borsh-derive",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -400,12 +525,44 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -443,6 +600,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher 0.3.0",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,9 +685,62 @@ checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.5.1",
+ "serde",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derivation-path"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -499,6 +761,41 @@ dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek-bip32"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
+dependencies = [
+ "derivation-path",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -525,6 +822,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "generic-array"
@@ -557,8 +860,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -566,6 +871,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -589,6 +903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,7 +938,7 @@ checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
  "digest 0.9.0",
  "generic-array",
- "hmac",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -616,12 +948,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
 dependencies = [
- "cfg-if",
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "rayon",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -638,6 +992,15 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -682,9 +1045,9 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "typenum",
 ]
 
@@ -752,6 +1115,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "mpl-token-metadata"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +1168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,12 +1190,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
 ]
 
 [[package]]
@@ -838,27 +1253,77 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pbkdf2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+dependencies = [
+ "crypto-mac",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "polyval"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -897,16 +1362,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.9.1"
+name = "qstring"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -926,9 +1387,19 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -938,7 +1409,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -951,12 +1432,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.8",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -986,12 +1507,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.16",
 ]
 
 [[package]]
@@ -1014,9 +1550,27 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1059,6 +1613,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1668,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest 0.10.6",
+ "keccak",
 ]
 
 [[package]]
@@ -1118,6 +1715,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,41 +1738,55 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.9.29"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4fcb89eb3d0f30bd4b4a31ad1825c9d95cd638509acead00969d7601713288"
+checksum = "48f7051cccdf891ac2603cdd295eb651529fe2b678b6b3af60b82dec9a9b3b06"
 dependencies = [
+ "ahash",
+ "blake3",
+ "block-buffer 0.9.0",
  "bs58 0.4.0",
  "bv",
+ "byteorder",
+ "cc",
+ "either",
  "generic-array",
+ "getrandom 0.1.16",
+ "hashbrown 0.12.3",
+ "im",
+ "lazy_static",
  "log",
  "memmap2",
- "rustc_version",
+ "once_cell",
+ "rand_core 0.6.4",
+ "rustc_version 0.4.0",
  "serde",
+ "serde_bytes",
  "serde_derive",
- "sha2",
+ "serde_json",
+ "sha2 0.10.6",
  "solana-frozen-abi-macro",
- "solana-logger",
+ "subtle",
  "thiserror",
 ]
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.9.29"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63ab101db88ecccd8da34065b9097b88367e0744fdfd05cb7de87b4ede3717f"
+checksum = "06395428329810ade1d2518a7e75d8a6f02d01fe548aabb60ff1ba6a2eaebbe5"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.9.29"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1805d52fc8277a84c4803c7850c8f41471b57fb0dec7750338955ad6e43e2"
+checksum = "170714ca3612e4df75f57c2c14c8ab74654b3b66f668986aeed456cedcf24446"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -1168,10 +1795,14 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.9.29"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5deafc4902425d40197f74166640300dd20b078e4ffd518c1bb56ceb7e01680"
+checksum = "1ae9f0fa7db3a4e90fa0df2723ac8cbc042e579cf109cd0380bc5a8c88bed924"
 dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "array-bytes",
  "base64 0.13.1",
  "bincode",
  "bitflags",
@@ -1181,39 +1812,99 @@ dependencies = [
  "bs58 0.4.0",
  "bv",
  "bytemuck",
+ "cc",
  "console_error_panic_hook",
  "console_log",
  "curve25519-dalek",
- "getrandom 0.1.16",
+ "getrandom 0.2.8",
+ "itertools",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "libsecp256k1",
+ "log",
+ "memoffset",
+ "num-bigint",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version 0.4.0",
+ "rustversion",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
+ "solana-frozen-abi",
+ "solana-frozen-abi-macro",
+ "solana-sdk-macro",
+ "thiserror",
+ "tiny-bip39",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbefda9f9bda78fd9d91ae21c38d9693e94d5979838fb69b70c6addb8dab953f"
+dependencies = [
+ "assert_matches",
+ "base64 0.13.1",
+ "bincode",
+ "bitflags",
+ "borsh",
+ "bs58 0.4.0",
+ "bytemuck",
+ "byteorder",
+ "chrono",
+ "derivation-path",
+ "digest 0.10.6",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "generic-array",
+ "hmac 0.12.1",
  "itertools",
  "js-sys",
  "lazy_static",
  "libsecp256k1",
  "log",
+ "memmap2",
  "num-derive",
  "num-traits",
- "parking_lot",
- "rand",
- "rustc_version",
+ "num_enum",
+ "pbkdf2 0.11.0",
+ "qstring",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc_version 0.4.0",
  "rustversion",
  "serde",
  "serde_bytes",
  "serde_derive",
- "sha2",
- "sha3",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-logger",
+ "solana-program",
  "solana-sdk-macro",
  "thiserror",
+ "uriparse",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.9.29"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db4c93bd43c91290ad54fe6ff86179a859954f196507c4789a4876d38a62f17"
+checksum = "f809319358d5da7c3a0ac08ebf4d87b21170d928dbb7260254e8f3061f7f9e0e"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2",
@@ -1229,27 +1920,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e0461f3afb29d8591300b3dd09b5472b3772d65688a2826ad960b8c0d5fa605"
 
 [[package]]
-name = "spl-associated-token-account"
-version = "1.0.5"
+name = "solana-zk-token-sdk"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b013067447a1396303ddfc294f36e3d260a32f8a16c501c295bcdc7de39b490"
+checksum = "9a290aa32014e007b03f952d5b784433d95636c65a3fb08d19dc5658a450941c"
 dependencies = [
+ "aes-gcm-siv",
+ "arrayref",
+ "base64 0.13.1",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "cipher 0.4.4",
+ "curve25519-dalek",
+ "getrandom 0.1.16",
+ "itertools",
+ "lazy_static",
+ "merlin",
+ "num-derive",
+ "num-traits",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "sha3 0.9.1",
+ "solana-program",
+ "solana-sdk",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "spl-associated-token-account"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978dba3bcbe88d0c2c58366c254d9ea41c5f73357e72fc0bdee4d6b5fc99c8f4"
+dependencies = [
+ "assert_matches",
  "borsh",
+ "num-derive",
+ "num-traits",
  "solana-program",
  "spl-token",
+ "spl-token-2022 0.6.1",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-memo"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0dc6f70db6bacea7ff25870b016a65ba1d1b6013536f08e4fd79a8f9005325"
+dependencies = [
+ "solana-program",
 ]
 
 [[package]]
 name = "spl-token"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc67166ef99d10c18cb5e9c208901e6d8255c6513bb1f877977eba48e6cc4fb"
+checksum = "8e85e168a785e82564160dcb87b2a8e04cee9bfd1f4d488c729d53d6a4bd300d"
 dependencies = [
  "arrayref",
+ "bytemuck",
  "num-derive",
  "num-traits",
  "num_enum",
  "solana-program",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edb869dbe159b018f17fb9bfa67118c30f232d7f54a73742bc96794dff77ed8"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo",
+ "spl-token",
+ "thiserror",
+]
+
+[[package]]
+name = "spl-token-2022"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0043b590232c400bad5ee9eb983ced003d15163c4c5d56b090ac6d9a57457b47"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-program",
+ "solana-zk-token-sdk",
+ "spl-memo",
+ "spl-token",
  "thiserror",
 ]
 
@@ -1266,6 +2039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +2059,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1312,6 +2103,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-bip39"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
+dependencies = [
+ "anyhow",
+ "hmac 0.8.1",
+ "once_cell",
+ "pbkdf2 0.4.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "sha2 0.9.9",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,16 +2152,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "version_check"
@@ -1452,13 +2318,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "yansi"
-version = "0.5.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/programs/staking-options/Cargo.toml
+++ b/programs/staking-options/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "staking_options"
-version = "0.0.8"
+version = "0.0.9"
 description = "Staking options from dual finance"
 edition = "2018"
 license = "Apache-2.0"
@@ -21,6 +21,5 @@ anchor-lang = "0.24.2"
 anchor-spl = "0.24.2"
 mpl-token-metadata =  {version = "1.4.0", features = ["no-entrypoint"]}
 solana-security-txt = "1.0.1"
-solana-program = "1.9.9"
+solana-program = "1.9.13"
 spl-token = {version = "3.1.1", features = ["no-entrypoint"]}
-vipers = "^2.0"

--- a/programs/staking-options/Cargo.toml
+++ b/programs/staking-options/Cargo.toml
@@ -17,8 +17,8 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.24.2"
-anchor-spl = "0.24.2"
+anchor-lang = "0.27.0"
+anchor-spl = "0.27.0"
 mpl-token-metadata =  {version = "1.4.0", features = ["no-entrypoint"]}
 solana-security-txt = "1.0.1"
 solana-program = "1.9.13"

--- a/programs/staking-options/src/common.rs
+++ b/programs/staking-options/src/common.rs
@@ -52,6 +52,5 @@ pub struct State {
     // authority above. This is useful in the case where a DAO is the one doing
     // the config, initStrike, withdraw, but a program is doing the issuing.
     pub issue_authority: Pubkey,
-
     // Padding of variable length.
 }

--- a/programs/staking-options/src/common.rs
+++ b/programs/staking-options/src/common.rs
@@ -47,5 +47,11 @@ pub struct State {
     // Vector of all strikes for an SO. Limit 100. For monitoring only.
     // A strike is number of quote atoms per lot.
     pub strikes: Vec<u64>,
-    // Padding
+
+    // If present, this issue authority is allowed to issue in addition to the
+    // authority above. This is useful in the case where a DAO is the one doing
+    // the config, initStrike, withdraw, but a program is doing the issuing.
+    pub issue_authority: Pubkey,
+
+    // Padding of variable length.
 }

--- a/programs/staking-options/src/errors.rs
+++ b/programs/staking-options/src/errors.rs
@@ -18,4 +18,12 @@ pub enum ErrorCode {
     IncorrectFeeAccount,
     #[msg("Not enough tokens to issue the SO")]
     NotEnoughTokens,
+    #[msg("Incorrect Authority")]
+    IncorrectAuthority,
+    #[msg("Too many strikes")]
+    TooManyStrikes,
+    #[msg("Invalid expiration")]
+    InvalidExpiration,
+    #[msg("Invalid name")]
+    InvalidName,
 }

--- a/programs/staking-options/src/errors.rs
+++ b/programs/staking-options/src/errors.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 #[error_code]
-pub enum ErrorCode {
+pub enum SOErrorCode {
     #[msg("The mint in the SO state did not match the token type being received")]
     WrongMint,
     #[msg("Expired")]

--- a/programs/staking-options/src/instructions/add_tokens.rs
+++ b/programs/staking-options/src/instructions/add_tokens.rs
@@ -20,7 +20,8 @@ pub fn add_tokens(ctx: Context<AddTokens>, num_tokens_to_add: u64) -> Result<()>
         .accounts
         .state
         .options_available
-        .checked_add(num_tokens_to_add).unwrap();
+        .checked_add(num_tokens_to_add)
+        .unwrap();
 
     Ok(())
 }
@@ -62,7 +63,11 @@ impl<'info> AddTokens<'info> {
 
         // Check that the token type matches the mint in the SO state that is
         // getting credited.
-        require_keys_eq!(self.base_account.mint, self.state.base_mint, SOErrorCode::WrongMint);
+        require_keys_eq!(
+            self.base_account.mint,
+            self.state.base_mint,
+            SOErrorCode::WrongMint
+        );
 
         // Do not allow adding tokens to an SO that is expired already.
         check_not_expired!(self.state.subscription_period_end);

--- a/programs/staking-options/src/instructions/add_tokens.rs
+++ b/programs/staking-options/src/instructions/add_tokens.rs
@@ -1,6 +1,6 @@
 use anchor_spl::token;
 use anchor_spl::token::{Token, TokenAccount};
-use vipers::prelude::*;
+use crate::ErrorCode::WrongMint;
 
 use crate::*;
 
@@ -17,11 +17,11 @@ pub fn add_tokens(ctx: Context<AddTokens>, num_tokens_to_add: u64) -> Result<()>
     token::transfer(cpi_ctx, num_tokens_to_add)?;
 
     // Update the state to reflect the newly available tokens for options.
-    ctx.accounts.state.options_available = unwrap_int!(ctx
+    ctx.accounts.state.options_available = ctx
         .accounts
         .state
         .options_available
-        .checked_add(num_tokens_to_add));
+        .checked_add(num_tokens_to_add).unwrap();
 
     Ok(())
 }
@@ -63,7 +63,7 @@ impl<'info> AddTokens<'info> {
 
         // Check that the token type matches the mint in the SO state that is
         // getting credited.
-        assert_keys_eq!(self.base_account.mint, self.state.base_mint, WrongMint);
+        require_keys_eq!(self.base_account.mint, self.state.base_mint, WrongMint);
 
         // Do not allow adding tokens to an SO that is expired already.
         check_not_expired!(self.state.subscription_period_end);

--- a/programs/staking-options/src/instructions/add_tokens.rs
+++ b/programs/staking-options/src/instructions/add_tokens.rs
@@ -1,6 +1,5 @@
 use anchor_spl::token;
 use anchor_spl::token::{Token, TokenAccount};
-use crate::ErrorCode::WrongMint;
 
 use crate::*;
 
@@ -63,7 +62,7 @@ impl<'info> AddTokens<'info> {
 
         // Check that the token type matches the mint in the SO state that is
         // getting credited.
-        require_keys_eq!(self.base_account.mint, self.state.base_mint, WrongMint);
+        require_keys_eq!(self.base_account.mint, self.state.base_mint, SOErrorCode::WrongMint);
 
         // Do not allow adding tokens to an SO that is expired already.
         check_not_expired!(self.state.subscription_period_end);

--- a/programs/staking-options/src/instructions/config.rs
+++ b/programs/staking-options/src/instructions/config.rs
@@ -135,7 +135,10 @@ impl<'info> ConfigV2<'info> {
         check_not_expired!(option_expiration);
         check_not_expired!(subscription_period_end);
 
-        require!(subscription_period_end <= option_expiration, SOErrorCode::InvalidExpiration);
+        require!(
+            subscription_period_end <= option_expiration,
+            SOErrorCode::InvalidExpiration
+        );
 
         // Cannot verify the token type of the quote_account because it could be
         // something else for downside SO.
@@ -268,7 +271,10 @@ impl<'info> Config<'info> {
         check_not_expired!(option_expiration);
         check_not_expired!(subscription_period_end);
 
-        require!(subscription_period_end <= option_expiration, SOErrorCode::InvalidExpiration);
+        require!(
+            subscription_period_end <= option_expiration,
+            SOErrorCode::InvalidExpiration
+        );
 
         // Cannot verify the token type of the quote_account because it could be
         // something else for downside SO.

--- a/programs/staking-options/src/instructions/config.rs
+++ b/programs/staking-options/src/instructions/config.rs
@@ -1,7 +1,6 @@
 use anchor_spl::token;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
-pub use crate::ErrorCode::InvalidName;
 pub use crate::*;
 
 pub fn config(
@@ -13,7 +12,7 @@ pub fn config(
     so_name: String,
 ) -> Result<()> {
     // Verify the SO name is a reasonable length.
-    require!(so_name.len() < 32, InvalidName);
+    require!(so_name.len() < 32, SOErrorCode::InvalidName);
 
     // Fill out the State
     ctx.accounts.state.so_name = so_name;
@@ -132,7 +131,7 @@ impl<'info> Config<'info> {
         check_not_expired!(option_expiration);
         check_not_expired!(subscription_period_end);
 
-        require!(subscription_period_end <= option_expiration, InvalidExpiration);
+        require!(subscription_period_end <= option_expiration, SOErrorCode::InvalidExpiration);
 
         // Cannot verify the token type of the quote_account because it could be
         // something else for downside SO.

--- a/programs/staking-options/src/instructions/config.rs
+++ b/programs/staking-options/src/instructions/config.rs
@@ -3,6 +3,147 @@ use anchor_spl::token::{Mint, Token, TokenAccount};
 
 pub use crate::*;
 
+pub fn config_v2(
+    ctx: Context<ConfigV2>,
+    option_expiration: u64,
+    subscription_period_end: u64,
+    num_tokens: u64,
+    lot_size: u64,
+    so_name: String,
+) -> Result<()> {
+    // Verify the SO name is a reasonable length.
+    require!(so_name.len() < 32, SOErrorCode::InvalidName);
+
+    // Fill out the State
+    ctx.accounts.state.so_name = so_name;
+    ctx.accounts.state.authority = ctx.accounts.so_authority.key();
+
+    let optional_issue_authority = &mut ctx.accounts.issue_authority;
+    if let Some(unwrapped_issue_authority) = optional_issue_authority {
+        ctx.accounts.state.issue_authority = unwrapped_issue_authority.key();
+    }
+    ctx.accounts.state.options_available = num_tokens;
+    ctx.accounts.state.option_expiration = option_expiration;
+    ctx.accounts.state.subscription_period_end = subscription_period_end;
+    ctx.accounts.state.base_decimals = ctx.accounts.base_mint.decimals;
+    ctx.accounts.state.quote_decimals = ctx.accounts.quote_mint.decimals;
+    ctx.accounts.state.base_mint = ctx.accounts.base_mint.key();
+    ctx.accounts.state.quote_mint = ctx.accounts.quote_mint.key();
+    ctx.accounts.state.quote_account = ctx.accounts.quote_account.key();
+    ctx.accounts.state.lot_size = lot_size;
+    // Do not need to initialize strikes as empty vector.
+
+    ctx.accounts.state.state_bump = *ctx.bumps.get("state").unwrap();
+    ctx.accounts.state.vault_bump = *ctx.bumps.get("base_vault").unwrap();
+
+    // Take tokens that will back the options.
+    let cpi_ctx = CpiContext::new(
+        ctx.accounts.token_program.to_account_info(),
+        token::Transfer {
+            from: ctx.accounts.base_account.to_account_info(),
+            to: ctx.accounts.base_vault.to_account_info(),
+            authority: ctx.accounts.authority.to_account_info(),
+        },
+    );
+    token::transfer(cpi_ctx, num_tokens)?;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(option_expiration: u64, subscription_period_end: u64, num_tokens: u64, lot_size: u64, so_name: String)]
+pub struct ConfigV2<'info> {
+    /// Does not have to match the authority for the SO State, but it can.
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// The authority that will be required init strike and withdrawing.
+    /// CHECK: Only used for comparing signers. Will be used in later transactions.
+    pub so_authority: AccountInfo<'info>,
+
+    /// An authority that can be used for issuing tokens. Should be a PDA.
+    /// CHECK: Only used for comparing signers. Will be used in later transactions.
+    pub issue_authority: Option<AccountInfo<'info>>,
+
+    /// State holding all the data for the stake that the staker wants to do.
+    #[account(
+        init,
+        payer = authority,
+        seeds = [SO_CONFIG_SEED, so_name.as_bytes(), &base_mint.key().to_bytes()],
+        bump,
+        space =
+          8 +       // discriminator
+          64 +      // so_name
+          32 +      // authority
+          8 +       // options_available
+          8 +       // option_expiration
+          8 +       // subscription_period_end
+          8 +       // decimals
+          32 +      // base_mint 
+          32 +      // quote_mint 
+          32 +      // quote_account 
+          8 +       // lot size
+          1 + 1 +   // bumps
+          8 +       // strikes overhead
+          8 * 100 + // strikes
+          32 +      // issue_authority
+          68        // unused bytes for future upgrades
+    )]
+    pub state: Box<Account<'info, State>>,
+
+    /// Where the base tokens are going to be held.
+    #[account(
+        init,
+        payer = authority,
+        seeds = [SO_VAULT_SEED, so_name.as_bytes(), &base_mint.key().to_bytes()],
+        bump,
+        token::mint = base_mint,
+        token::authority = base_vault)]
+    pub base_vault: Box<Account<'info, TokenAccount>>,
+
+    /// Where the tokens are coming from.
+    #[account(mut)]
+    pub base_account: Box<Account<'info, TokenAccount>>,
+
+    /// Saved for later. Not used. TokenAccount instead of AccountInfo in order
+    /// to get the anchor type checking.
+    pub quote_account: Box<Account<'info, TokenAccount>>,
+
+    /// Mint of base tokens.
+    pub base_mint: Box<Account<'info, Mint>>,
+    /// Mint of quote tokens. Needed for storing the number of decimals.
+    pub quote_mint: Box<Account<'info, Mint>>,
+
+    pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+impl<'info> ConfigV2<'info> {
+    pub fn validate_accounts(
+        &self,
+        option_expiration: u64,
+        subscription_period_end: u64,
+    ) -> Result<()> {
+        // Verify the type of token matches input
+        require_keys_eq!(self.base_mint.key(), self.base_account.mint.key());
+        require_keys_eq!(self.quote_mint.key(), self.quote_account.mint.key());
+
+        // num_tokens is verified by the token program doing the transfer.
+
+        // Make sure it is not already expired.
+        check_not_expired!(option_expiration);
+        check_not_expired!(subscription_period_end);
+
+        require!(subscription_period_end <= option_expiration, SOErrorCode::InvalidExpiration);
+
+        // Cannot verify the token type of the quote_account because it could be
+        // something else for downside SO.
+
+        Ok(())
+    }
+}
+
 pub fn config(
     ctx: Context<Config>,
     option_expiration: u64,
@@ -17,7 +158,7 @@ pub fn config(
     // Fill out the State
     ctx.accounts.state.so_name = so_name;
     ctx.accounts.state.authority = ctx.accounts.so_authority.key();
-    ctx.accounts.state.issue_authority = ctx.accounts.issue_authority.key();
+
     ctx.accounts.state.options_available = num_tokens;
     ctx.accounts.state.option_expiration = option_expiration;
     ctx.accounts.state.subscription_period_end = subscription_period_end;
@@ -56,10 +197,6 @@ pub struct Config<'info> {
     /// The authority that will be required init strike and withdrawing.
     /// CHECK: Only used for comparing signers. Will be used in later transactions.
     pub so_authority: AccountInfo<'info>,
-
-    /// An authority that can be used for issuing tokens. Should be a PDA.
-    /// CHECK: Only used for comparing signers. Will be used in later transactions.
-    pub issue_authority: AccountInfo<'info>,
 
     /// State holding all the data for the stake that the staker wants to do.
     #[account(

--- a/programs/staking-options/src/instructions/exercise.rs
+++ b/programs/staking-options/src/instructions/exercise.rs
@@ -1,6 +1,5 @@
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
-pub use crate::ErrorCode::IncorrectFeeAccount;
 pub use crate::*;
 
 pub fn exercise(ctx: Context<Exercise>, amount_lots: u64, strike: u64) -> Result<()> {
@@ -151,7 +150,7 @@ impl<'info> Exercise<'info> {
         require_keys_eq!(
             self.state.quote_account.key(),
             self.project_quote_account.key(),
-            IncorrectFeeAccount
+            SOErrorCode::IncorrectFeeAccount
         );
 
         // Verify that it is owned by DUAL.

--- a/programs/staking-options/src/instructions/exercise.rs
+++ b/programs/staking-options/src/instructions/exercise.rs
@@ -88,7 +88,9 @@ pub fn exercise(ctx: Context<Exercise>, amount_lots: u64, strike: u64) -> Result
                 &[ctx.accounts.state.vault_bump],
             ]],
         ),
-        amount_lots.checked_mul(ctx.accounts.state.lot_size).unwrap(),
+        amount_lots
+            .checked_mul(ctx.accounts.state.lot_size)
+            .unwrap(),
     )?;
 
     Ok(())

--- a/programs/staking-options/src/instructions/init_strike.rs
+++ b/programs/staking-options/src/instructions/init_strike.rs
@@ -1,7 +1,6 @@
-use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token};
 
-pub use crate::ErrorCode::TooManyStrikes;
+pub use crate::*;
 pub use crate::common::*;
 
 pub fn init_strike(ctx: Context<InitStrike>, strike: u64) -> Result<()> {
@@ -51,7 +50,7 @@ impl<'info> InitStrike<'info> {
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are not too many strikes already.
-        require!(self.state.strikes.len() < 100, TooManyStrikes);
+        require!(self.state.strikes.len() < 100, SOErrorCode::TooManyStrikes);
 
         Ok(())
     }
@@ -107,7 +106,7 @@ impl<'info> InitStrikeWithPayer<'info> {
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are not too many strikes already.
-        require!(self.state.strikes.len() < 100, TooManyStrikes);
+        require!(self.state.strikes.len() < 100, SOErrorCode::TooManyStrikes);
 
         Ok(())
     }

--- a/programs/staking-options/src/instructions/init_strike.rs
+++ b/programs/staking-options/src/instructions/init_strike.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token};
-use vipers::prelude::*;
 
+pub use crate::ErrorCode::TooManyStrikes;
 pub use crate::common::*;
 
 pub fn init_strike(ctx: Context<InitStrike>, strike: u64) -> Result<()> {
@@ -45,13 +45,13 @@ pub struct InitStrike<'info> {
 impl<'info> InitStrike<'info> {
     pub fn validate_accounts(&self, _strike: u64) -> Result<()> {
         // Verify the authority to init strike against the state authority
-        assert_keys_eq!(self.authority, self.state.authority);
+        require_keys_eq!(self.authority.key(), self.state.authority);
 
         // Verify that it is not already expired
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are not too many strikes already.
-        invariant!(self.state.strikes.len() < 100);
+        require!(self.state.strikes.len() < 100, TooManyStrikes);
 
         Ok(())
     }
@@ -101,13 +101,13 @@ pub struct InitStrikeWithPayer<'info> {
 impl<'info> InitStrikeWithPayer<'info> {
     pub fn validate_accounts(&self, _strike: u64) -> Result<()> {
         // Verify the authority to init strike against the state authority
-        assert_keys_eq!(self.authority, self.state.authority);
+        require_keys_eq!(self.authority.key(), self.state.authority);
 
         // Verify that it is not already expired
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are not too many strikes already.
-        invariant!(self.state.strikes.len() < 100);
+        require!(self.state.strikes.len() < 100, TooManyStrikes);
 
         Ok(())
     }

--- a/programs/staking-options/src/instructions/init_strike.rs
+++ b/programs/staking-options/src/instructions/init_strike.rs
@@ -1,7 +1,7 @@
 use anchor_spl::token::{Mint, Token};
 
-pub use crate::*;
 pub use crate::common::*;
+pub use crate::*;
 
 pub fn init_strike(ctx: Context<InitStrike>, strike: u64) -> Result<()> {
     ctx.accounts.state.strikes.push(strike);

--- a/programs/staking-options/src/instructions/issue.rs
+++ b/programs/staking-options/src/instructions/issue.rs
@@ -27,8 +27,12 @@ pub fn issue(ctx: Context<Issue>, amount: u64, strike: u64) -> Result<()> {
     )?;
 
     // Update state to reflect the number of available tokens
-    ctx.accounts.state.options_available =
-        ctx.accounts.state.options_available.checked_sub(amount).unwrap();
+    ctx.accounts.state.options_available = ctx
+        .accounts
+        .state
+        .options_available
+        .checked_sub(amount)
+        .unwrap();
 
     Ok(())
 }
@@ -66,14 +70,17 @@ impl<'info> Issue<'info> {
         require!(
             self.authority.key.to_bytes() == self.state.authority.to_bytes()
                 || self.authority.key.to_bytes() == self.state.issue_authority.to_bytes(),
-                SOErrorCode::IncorrectAuthority
+            SOErrorCode::IncorrectAuthority
         );
 
         // Verify subscription period
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are enough tokens to back the options.
-        require!(self.state.options_available >= amount, SOErrorCode::NotEnoughTokens);
+        require!(
+            self.state.options_available >= amount,
+            SOErrorCode::NotEnoughTokens
+        );
 
         // Do not need to verify the SO mint is at the right address. The
         // authority check is sufficient. If a different mint was somehow

--- a/programs/staking-options/src/instructions/issue.rs
+++ b/programs/staking-options/src/instructions/issue.rs
@@ -1,6 +1,5 @@
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
-pub use crate::ErrorCode::IncorrectAuthority;
 pub use crate::*;
 
 pub fn issue(ctx: Context<Issue>, amount: u64, strike: u64) -> Result<()> {
@@ -67,14 +66,14 @@ impl<'info> Issue<'info> {
         require!(
             self.authority.key.to_bytes() == self.state.authority.to_bytes()
                 || self.authority.key.to_bytes() == self.state.issue_authority.to_bytes(),
-                IncorrectAuthority
+                SOErrorCode::IncorrectAuthority
         );
 
         // Verify subscription period
         check_not_expired!(self.state.subscription_period_end);
 
         // Make sure there are enough tokens to back the options.
-        require!(self.state.options_available >= amount, NotEnoughTokens);
+        require!(self.state.options_available >= amount, SOErrorCode::NotEnoughTokens);
 
         // Do not need to verify the SO mint is at the right address. The
         // authority check is sufficient. If a different mint was somehow

--- a/programs/staking-options/src/instructions/withdraw.rs
+++ b/programs/staking-options/src/instructions/withdraw.rs
@@ -1,7 +1,7 @@
-use anchor_lang::prelude::*;
 use anchor_lang::AccountsClose;
 use anchor_spl::token::{Token, TokenAccount};
 
+pub use crate::*;
 pub use crate::common::*;
 
 pub fn withdraw(ctx: Context<Withdraw>) -> Result<()> {

--- a/programs/staking-options/src/instructions/withdraw.rs
+++ b/programs/staking-options/src/instructions/withdraw.rs
@@ -1,7 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::AccountsClose;
 use anchor_spl::token::{Token, TokenAccount};
-use vipers::prelude::*;
 
 pub use crate::common::*;
 
@@ -84,8 +83,8 @@ pub struct Withdraw<'info> {
 
 impl<'info> Withdraw<'info> {
     pub fn validate_accounts(&self) -> Result<()> {
-        // Verify the authority to init strike against the state authority.
-        assert_keys_eq!(self.authority, self.state.authority);
+        // Verify the authority to withdraw against the state authority.
+        require_keys_eq!(self.authority.key(), self.state.authority);
 
         // Verify that subscription period has ended.
         check_expired!(self.state.subscription_period_end);

--- a/programs/staking-options/src/instructions/withdraw.rs
+++ b/programs/staking-options/src/instructions/withdraw.rs
@@ -1,8 +1,8 @@
 use anchor_lang::AccountsClose;
 use anchor_spl::token::{Token, TokenAccount};
 
-pub use crate::*;
 pub use crate::common::*;
+pub use crate::*;
 
 pub fn withdraw(ctx: Context<Withdraw>) -> Result<()> {
     // Allow partial withdraw after the subscription period end.

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -53,6 +53,29 @@ pub mod staking_options {
         )
     }
 
+    // A new config is needed to make the issue authority optional. Making the
+    // new optional field is a breaking change for anything that uses the idl,
+    // so we are using a separate function. The original should be deprecated
+    // once the sdk usage all gets past the broken version.
+    #[access_control(ctx.accounts.validate_accounts(option_expiration, subscription_period_end))]
+    pub fn config_v2(
+        ctx: Context<ConfigV2>,
+        option_expiration: u64,
+        subscription_period_end: u64,
+        num_tokens: u64,
+        lot_size: u64,
+        so_name: String,
+    ) -> Result<()> {
+        config::config_v2(
+            ctx,
+            option_expiration,
+            subscription_period_end,
+            num_tokens,
+            lot_size,
+            so_name,
+        )
+    }
+
     #[access_control(ctx.accounts.validate_accounts(amount, strike))]
     pub fn exercise(ctx: Context<Exercise>, amount: u64, strike: u64) -> Result<()> {
         exercise::exercise(ctx, amount, strike)

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -8,8 +8,7 @@ mod errors;
 mod instructions;
 
 pub use crate::common::*;
-pub use crate::errors::ErrorCode;
-pub use crate::ErrorCode::InvalidMint;
+pub use crate::errors::SOErrorCode;
 pub use crate::instructions::*;
 
 #[cfg(not(feature = "no-entrypoint"))]

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use vipers::prelude::*;
 
 #[macro_use]
 mod macros;
@@ -10,6 +9,7 @@ mod instructions;
 
 pub use crate::common::*;
 pub use crate::errors::ErrorCode;
+pub use crate::ErrorCode::InvalidMint;
 pub use crate::instructions::*;
 
 #[cfg(not(feature = "no-entrypoint"))]

--- a/programs/staking-options/src/macros.rs
+++ b/programs/staking-options/src/macros.rs
@@ -2,7 +2,7 @@ macro_rules! check_not_expired {
     ($expiration:expr) => {
         require!(
             Clock::get().unwrap().unix_timestamp as u64 <= $expiration,
-            Expired
+            SOErrorCode::Expired
         );
     };
 }
@@ -11,7 +11,7 @@ macro_rules! check_expired {
     ($expiration:expr) => {
         require!(
             Clock::get().unwrap().unix_timestamp as u64 > $expiration,
-            NotYetExpired
+            SOErrorCode::NotYetExpired
         );
     };
 }
@@ -28,7 +28,7 @@ macro_rules! check_mint {
             $ctx.program_id,
         );
 
-        require_keys_eq!($ctx.accounts.option_mint.key(), expected_mint, InvalidMint);
+        require_keys_eq!($ctx.accounts.option_mint.key(), expected_mint, SOErrorCode::InvalidMint);
         let $bump = mint_bump;
     };
 }

--- a/programs/staking-options/src/macros.rs
+++ b/programs/staking-options/src/macros.rs
@@ -28,7 +28,11 @@ macro_rules! check_mint {
             $ctx.program_id,
         );
 
-        require_keys_eq!($ctx.accounts.option_mint.key(), expected_mint, SOErrorCode::InvalidMint);
+        require_keys_eq!(
+            $ctx.accounts.option_mint.key(),
+            expected_mint,
+            SOErrorCode::InvalidMint
+        );
         let $bump = mint_bump;
     };
 }

--- a/programs/staking-options/src/macros.rs
+++ b/programs/staking-options/src/macros.rs
@@ -1,6 +1,6 @@
 macro_rules! check_not_expired {
     ($expiration:expr) => {
-        invariant!(
+        require!(
             Clock::get().unwrap().unix_timestamp as u64 <= $expiration,
             Expired
         );
@@ -9,7 +9,7 @@ macro_rules! check_not_expired {
 
 macro_rules! check_expired {
     ($expiration:expr) => {
-        invariant!(
+        require!(
             Clock::get().unwrap().unix_timestamp as u64 > $expiration,
             NotYetExpired
         );
@@ -28,7 +28,7 @@ macro_rules! check_mint {
             $ctx.program_id,
         );
 
-        assert_keys_eq!($ctx.accounts.option_mint.key(), expected_mint, InvalidMint);
+        require_keys_eq!($ctx.accounts.option_mint.key(), expected_mint, InvalidMint);
         let $bump = mint_bump;
     };
 }


### PR DESCRIPTION
Fixes #42 

Needed to update to anchor 0.27.0 to use optional accounts
Remove vipers because it only supports up to 0.25.0

Needed to make a separate config v2 because using optional accounts is a breaking change for all clients that use an idl. Note that because the affected part of the state is at the end, it does not break existing Staking Options States