### PR TITLE
Add modify expiration instruction

### DIFF
--- a/.github/workflows/ci-anchor.yml
+++ b/.github/workflows/ci-anchor.yml
@@ -9,7 +9,7 @@ jobs:
     container: projectserum/build:v0.26.0
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: List rustup toolchains
         run: rustup toolchain list

--- a/.github/workflows/ci-anchor.yml
+++ b/.github/workflows/ci-anchor.yml
@@ -9,7 +9,7 @@ jobs:
     container: projectserum/build:v0.26.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: List rustup toolchains
         run: rustup toolchain list

--- a/programs/staking-options/src/instructions/mod.rs
+++ b/programs/staking-options/src/instructions/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod exercise;
 pub mod init_strike;
 pub mod issue;
+pub mod modify_expiration;
 pub mod name_token;
 pub mod withdraw;
 
@@ -11,5 +12,6 @@ pub use config::*;
 pub use exercise::*;
 pub use init_strike::*;
 pub use issue::*;
+pub use modify_expiration::*;
 pub use name_token::*;
 pub use withdraw::*;

--- a/programs/staking-options/src/instructions/modify_expiration.rs
+++ b/programs/staking-options/src/instructions/modify_expiration.rs
@@ -1,0 +1,43 @@
+use anchor_spl::token::{TokenAccount, Mint};
+
+pub use crate::common::*;
+pub use crate::*;
+
+pub fn modify_expiration(ctx: Context<ModifyExpiration>, new_expiration_unix_sec: u64) -> Result<()> {
+    // Only allow accelerating expiration.
+    assert!(ctx.accounts.state.option_expiration > new_expiration_unix_sec);
+
+    // Require that the authority holds all the outstanding options and no more are issued.
+
+    // Only 1 strike because strikes are independent.
+    assert!(ctx.accounts.state.strikes.len() == 1);
+    assert!(ctx.accounts.user_so_account.owner == *ctx.accounts.authority.key);
+    assert!(ctx.accounts.user_so_account.amount == ctx.accounts.option_mint.supply);
+
+    ctx.accounts.state.option_expiration = new_expiration_unix_sec;
+
+    Ok(())
+}
+
+#[derive(Accounts)]
+#[instruction(new_expiration_unix_sec: u64)]
+pub struct ModifyExpiration<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    /// State holding all the data for the stake that the staker wants to do.
+    #[account(mut,
+        seeds = [
+            SO_CONFIG_SEED,
+            state.so_name.as_bytes(),
+            &state.base_mint.key().to_bytes()
+        ],
+        bump = state.state_bump
+    )]
+    pub state: Account<'info, State>,
+
+    /// User must have all the outstanding staking options for the SO mint.
+    pub user_so_account: Box<Account<'info, TokenAccount>>,
+    /// Mint is needed to get the number of outstanding options.
+    pub option_mint: Box<Account<'info, Mint>>,
+}

--- a/programs/staking-options/src/instructions/modify_expiration.rs
+++ b/programs/staking-options/src/instructions/modify_expiration.rs
@@ -1,9 +1,12 @@
-use anchor_spl::token::{TokenAccount, Mint};
+use anchor_spl::token::{Mint, TokenAccount};
 
 pub use crate::common::*;
 pub use crate::*;
 
-pub fn modify_expiration(ctx: Context<ModifyExpiration>, new_expiration_unix_sec: u64) -> Result<()> {
+pub fn modify_expiration(
+    ctx: Context<ModifyExpiration>,
+    new_expiration_unix_sec: u64,
+) -> Result<()> {
     // Only allow accelerating expiration.
     assert!(ctx.accounts.state.option_expiration > new_expiration_unix_sec);
 

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -149,4 +149,9 @@ pub mod staking_options {
     pub fn withdraw_all(ctx: Context<WithdrawAll>) -> Result<()> {
         withdraw::withdraw_all(ctx)
     }
+
+    // Access control checked in the handler.
+    pub fn modify_expiration(ctx: Context<ModifyExpiration>, new_expiration_unix_sec: u64) -> Result<()> {
+        modify_expiration::modify_expiration(ctx, new_expiration_unix_sec)
+    }
 }

--- a/programs/staking-options/src/lib.rs
+++ b/programs/staking-options/src/lib.rs
@@ -151,7 +151,10 @@ pub mod staking_options {
     }
 
     // Access control checked in the handler.
-    pub fn modify_expiration(ctx: Context<ModifyExpiration>, new_expiration_unix_sec: u64) -> Result<()> {
+    pub fn modify_expiration(
+        ctx: Context<ModifyExpiration>,
+        new_expiration_unix_sec: u64,
+    ) -> Result<()> {
         modify_expiration::modify_expiration(ctx, new_expiration_unix_sec)
     }
 }


### PR DESCRIPTION
A user can surrender the ability to continue to exercise or reverse exercise prior to expiration.